### PR TITLE
Fix tap handler being null in MarkdownTemplate when used in MarkdownPage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+- Fix a bug with markdown tap handler being null introduced in 1.3.0
+
 ## 1.3.0
 
 - Allow custom tap handlers for links in markdown pages

--- a/lib/src/markdown.dart
+++ b/lib/src/markdown.dart
@@ -97,9 +97,10 @@ class MarkdownTemplate extends StatefulWidget {
     bool useMustache,
     this.mustacheValues,
     @required this.filename,
-    this.tapHandler = const UrlMarkdownTapHandler(),
+    MarkdownTapHandler tapHandler,
   })  : assert(filename != null),
         useMustache = useMustache ?? mustacheValues != null,
+        tapHandler = tapHandler ?? const UrlMarkdownTapHandler(),
         super(key: key);
 
   /// The name of the application.
@@ -240,7 +241,7 @@ class MarkdownPage extends StatefulWidget {
     bool useMustache,
     this.mustacheValues,
     @required this.filename,
-    this.tapHandler = const UrlMarkdownTapHandler(),
+    this.tapHandler,
   })  : assert(filename != null),
         useMustache = useMustache ?? mustacheValues != null,
         super(key: key);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: about
 description: Displays an About dialog, which describes the application, can show licenses, changelog, and other information.
 author: David PHAM-VAN <dev.nfet.net@gmail.com>
 homepage: https://github.com/DavBfr/flutter_about
-version: 1.3.0
+version: 1.3.1
 
 environment:
   sdk: ">=2.2.2 <3.0.0"


### PR DESCRIPTION
Really sorry about this, only tested with `MarkdownTemplate` before. 