### PR TITLE
Pass custom ScaffoldBuilder to LicenseDetail

### DIFF
--- a/lib/src/licenses.dart
+++ b/lib/src/licenses.dart
@@ -171,6 +171,7 @@ class _LicenseListPageState extends State<LicenseListPage> {
               return LicenseDetail(
                 package: packageName,
                 paragraphs: paragraphs,
+                scaffoldBuilder: widget.scaffoldBuilder
               );
             }
 


### PR DESCRIPTION
PR for #19 .

I'm deliberately passing in a potentially null value, relying on LicenseDetail to use its own default if the value is null. (Currently, the default scaffold for both the list and the detail is the same, but it might not always be.)

However, if you'd consider `widget.scaffoldBuilder ?? defaultScaffoldBuilder` to be a better solution here, let me know, I have no problem changing this. :)